### PR TITLE
Some tweaks to the WB comparison

### DIFF
--- a/docs/srcs/comparison.md
+++ b/docs/srcs/comparison.md
@@ -721,6 +721,7 @@ There are many mod managers around these days and it's may be a bit difficult to
 				Account login,
 				Download with manager,
 				Mod update check
+			</td>
 			<td id="MO2">
 				Account login,
 				Download with manager,
@@ -732,6 +733,7 @@ There are many mod managers around these days and it's may be a bit difficult to
 			</td>
 			<td id="MO1">
 				Integration no longer works since Nexus API update.
+			</td>
 			<td id="Vortex">
 				Account login,
 				Download with manager,
@@ -830,7 +832,7 @@ There are many mod managers around these days and it's may be a bit difficult to
 			</td>
 			<td id="WB">
 				<a href="https://wrye-bash.github.io/docs/Wrye%20Bash%20Advanced%20Readme.html#bainAddMarker">Customizable marker system</a> for archives,
-				<a href="https://wrye-bash.github.io/docs/Wrye%20Bash%20Advanced%20Readme.html#mods-commands">Customizable groups system</a> for plugins.
+				<a href="https://wrye-bash.github.io/docs/Wrye%20Bash%20Advanced%20Readme.html#mods-commands">customizable groups system</a> for plugins.
 			</td>
 		</tr>
 		<tr>
@@ -839,38 +841,48 @@ There are many mod managers around these days and it's may be a bit difficult to
 				<div class="cmp-no" />
 			</td>
 			<td id="MO2">
-				Plugins with missing masters,
-				Files in overwrite,
-				Form 43 plugins for Skyrim SE,
-				Script Extender plugin load failure,
-				Need to run FNIS,
-				Presence of files with attributes that the game can't handle.
+				<ul>
+					<li>Plugins with missing masters</li>
+					<li>Files in overwrite</li>
+					<li>Form 43 plugins for Skyrim SE</li>
+					<li>Script Extender plugin load failure</li>
+					<li>Need to run FNIS</li>
+					<li>Presence of files with attributes that the game can't handle</li>
+				</ul>
 			</td>
 			<td id="MO1">
-				Plugins with missing masters,
-				Files in overwrite,
-				Need to run FNIS.
+				<ul>
+					<li>Plugins with missing masters</li>
+					<li>Files in overwrite</li>
+					<li>Need to run FNIS</li>
+				</ul>
 			</td>
 			<td id="Vortex">
-				Bug report automation in menu.
-				Notifications in the bell icon including xSE error notifications.
-				Missing masters?
-				Form 43 with loot?
+				<ul>
+					<li>Bug report automation in menu</li>
+					<li>Notifications in the bell icon including xSE error notifications.</li>
+					<li>Missing masters?</li>
+					<li>Form 43 with LOOT?</li>
+				</ul>
 			</td>
 			<td id="NMM">
-				Missing masters.
+				<ul>
+					<li>Missing masters</li>
+				</ul>
 			</td>
 			<td id="WB">
-				Missing masters,
-				Out of order masters,
-				Missing strings files,
-				Form 43 plugins for Skyrim SE,
-				ESL verification,
-				File using same date for games that utilize a time date stamp,
-				Ghosted plugin verification,
-				Dirty edit scanning,
-				Deactivate and NoMerge verification,
-				<span tooltip="WIP version only">Mismatched BSA version detection</span>.
+				<ul>
+					<li>Missing masters</li>
+					<li>Out of order masters</li>
+					<li>Missing strings files</li>
+					<li>Form 43 plugins for Skyrim SE</li>
+					<li>ESL verification</li>
+					<li>File using same date for games that utilize a time date stamp</li>
+					<li>Ghosted plugin verification</li>
+					<li>Dirty edit scanning</li>
+					<li>Deactivate and NoMerge verification</li>
+					<li><span tooltip="WIP version only">Mismatched BSA version detection</span></li>
+				</ul>
 			</td>
 		</tr>
 		<tr>
@@ -1104,9 +1116,10 @@ There are many mod managers around these days and it's may be a bit difficult to
 					<li>Japanese</li>
 					<li>Portuguese</li>
 					<li>Russian</li>
-					<li>Non-English languages are <b>very</b> outdated, and further localization efforts are currently postponed until Wrye Bash has been ported to Python 3.</li>
-					<li><a href="https://wrye-bash.github.io/docs/Wrye%20Bash%20Advanced%20Readme.html#international">Localization can be easily exported</a> and edited with Notepad++ or Poedit.</li>
 				</ul>
+				<br/>
+				Non-English languages are <b>very</b> outdated, and further localization efforts are currently postponed until Wrye Bash has been ported to Python 3.
+				<a href="https://wrye-bash.github.io/docs/Wrye%20Bash%20Advanced%20Readme.html#international">Localization can be easily exported</a> and edited with Notepad++ or Poedit.
 			</td>
 		</tr>
 		<tr>

--- a/docs/srcs/comparison.md
+++ b/docs/srcs/comparison.md
@@ -265,7 +265,7 @@ There are many mod managers around these days and it's may be a bit difficult to
 				<div class="cmp-no" />
 			</td>
 			<td id="WB">
-				<div class="cmp-yes" tooltip="Not supported for compressed save game headers like in Skyrim SE"/>
+				<div class="cmp-yes" tooltip="Compressed save game headers like in Skyrim SE only supported in WIP version"/>
 			</td>
 		</tr>
 		<tr>
@@ -389,7 +389,7 @@ There are many mod managers around these days and it's may be a bit difficult to
 				<div class="cmp-no" />
 			</td>
 			<td id="WB">
-				<div class="cmp-no" />
+				Visualization of dirty plugins via underlining on the plugin list, automatic retrieval of LOOT's Bash Tag suggestions.
 			</td>
 		</tr>
 		<tr>
@@ -829,7 +829,8 @@ There are many mod managers around these days and it's may be a bit difficult to
 				Import from nexus, and create custom categories.
 			</td>
 			<td id="WB">
-				<a href="https://wrye-bash.github.io/docs/Wrye Bash Advanced Readme.html#bainAddMarker">Custom marker system</a>.
+				<a href="https://wrye-bash.github.io/docs/Wrye%20Bash%20Advanced%20Readme.html#bainAddMarker">Customizable marker system</a> for archives,
+				<a href="https://wrye-bash.github.io/docs/Wrye%20Bash%20Advanced%20Readme.html#mods-commands">Customizable groups system</a> for plugins.
 			</td>
 		</tr>
 		<tr>
@@ -860,7 +861,16 @@ There are many mod managers around these days and it's may be a bit difficult to
 				Missing masters.
 			</td>
 			<td id="WB">
-				Missing masters, out of order masters, missing strings files, Form 43 plugins for Skyrim SE, ESL verification, File using same date for games that utilize a time date stamp, ghosted plugin, dirty edits, improperly configured plugins marked with Deactivate or NoMerge.
+				Missing masters,
+				Out of order masters,
+				Missing strings files,
+				Form 43 plugins for Skyrim SE,
+				ESL verification,
+				File using same date for games that utilize a time date stamp,
+				Ghosted plugin verification,
+				Dirty edit scanning,
+				Deactivate and NoMerge verification,
+				<span tooltip="WIP version only">Mismatched BSA version detection</span>.
 			</td>
 		</tr>
 		<tr>
@@ -997,7 +1007,7 @@ There are many mod managers around these days and it's may be a bit difficult to
 					<li>List file dependencies</li>
 					<li>Jump to assigned Installer from Mods List</li>
 					<li>Check ESL Qualifications for ESL enabled games</li>
-					<li>Export Editor IDs to .csv File</li>
+					<li>Export/import various subrecords to/from .csv files</li>
 					<li>List LOOT Cleaning Information</li>
 					<li>Copy .esp to .esm file (Creates file in Data Folder)</li>
 					<li>Add Remove ESL or ESM flags</li>
@@ -1087,8 +1097,15 @@ There are many mod managers around these days and it's may be a bit difficult to
 			<td id="WB">
 				<ul>
 					<li>English</li>
+					<li>Chinese (Simplified)</li>
+					<li>Chinese (Traditional)</li>
+					<li>German</li>
+					<li>Italian</li>
+					<li>Japanese</li>
+					<li>Portuguese</li>
+					<li>Russian</li>
+					<li>Non-English languages are <b>very</b> outdated, and further localization efforts are currently postponed until Wrye Bash has been ported to Python 3.</li>
 					<li><a href="https://wrye-bash.github.io/docs/Wrye%20Bash%20Advanced%20Readme.html#international">Localization can be easily exported</a> and edited with Notepad++ or Poedit.</li>
-					<li>Language changes are very outdated.</li>
 				</ul>
 			</td>
 		</tr>


### PR DESCRIPTION
- WIP version now supports SSE save editing
- We do have some limited LOOT integration
- Markers are for archives, for plugins we have Groups (and Ratings, but those will probably be merged into groups at some point)
- Made the problem detection features more readable, and added the WIP BSA version mismatch detection.
- Games other than SSE and FO4 can export a whole load more than just editor IDs to CSV files :)
- Added the languages that WB is translated for, and also noted that further localization work will currently have to wait